### PR TITLE
Adds actions initialize stack and finding stack files for testing GHC versions

### DIFF
--- a/find-stack-ghc-yamls/action.yaml
+++ b/find-stack-ghc-yamls/action.yaml
@@ -1,8 +1,10 @@
-name: Find stack.yaml files configured for specific GHC verions
+name: Find stack.yaml files configured for specific GHC versions
+
 outputs:
   stack-yamls:
     description: The files matching stack-ghc*.yaml that were found
     value: ${{ steps.set-output.outputs.stack-yamls }}
+
 runs:
   using: composite
   steps:
@@ -13,6 +15,7 @@ runs:
       id: set-output
       shell: bash
       run: |
+        set -o errexit
         shopt -s failglob
         files=(stack-ghc*.yaml)
         json=$(jq --null-input --compact-output '$ARGS.positional' --args "${files[@]}")

--- a/setup-dockerized-stack/action.yaml
+++ b/setup-dockerized-stack/action.yaml
@@ -1,0 +1,42 @@
+name: Setup Dockerized Stack
+description: Sets up a project's dockerized stack in the "normal" way for our projects
+
+inputs:
+  stack-root:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup
+      shell: bash
+      env:
+        STACK_CONFIG: ${{ github.workspace }}/stack-config.yaml
+      run: |
+        set -o errexit
+        
+        # Allow stack to use the provided stack root we're making
+        # even though it's owned by a different user
+        echo 'allow-different-user: true' >> $STACK_CONFIG
+
+        # Create a compose override file that sets up the stack
+        # environment for any scripts that the build will run to
+        # run after this setup.
+        cat <<- EOF > compose.override.yml
+        services:
+          dev:
+            environment:
+              STACK_ROOT: /stack-root
+              STACK_CONFIG: $STACK_CONFIG
+            volumes:
+              - ${{ inputs.stack-root }}:/stack-root
+        EOF
+
+        # On a build where no cache was hit, we need the stack-root
+        # directory to exist
+        mkdir -p ${{ inputs.stack-root }}
+
+        # The compose.yml files of our projects use $PROJECT_DIR to
+        # make the work dir inside the container match the path on the
+        # host.
+        echo "PROJECT_DIR=$PWD" >> .env


### PR DESCRIPTION
Based on the `json-fleece` build and the others we're about to update, these actions are going to end up being duplicated across a number of our repositories. This extracts them so that can be re-used.